### PR TITLE
feat(hermes): add API server, dashboard, and systemd service templates

### DIFF
--- a/hermes/.config/systemd/user/hermes-dashboard.service
+++ b/hermes/.config/systemd/user/hermes-dashboard.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Hermes Agent Dashboard - Web UI & Remote Desktop Backend
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+ExecStart=<HERMES_VENV_PYTHON> -m hermes_cli.main dashboard --no-open --host 0.0.0.0 --port 9119
+WorkingDirectory=%h/.hermes
+Environment="PATH=<HERMES_VENV_BIN>:<HERMES_NODE_BIN>:/usr/bin:%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="VIRTUAL_ENV=<HERMES_VENV>"
+Environment="HERMES_HOME=%h/.hermes"
+EnvironmentFile=%h/.hermes/.env
+Restart=always
+RestartSec=5
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=210
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/hermes/.config/systemd/user/hermes-gateway.service
+++ b/hermes/.config/systemd/user/hermes-gateway.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Hermes Agent Gateway - Messaging Platform Integration
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+ExecStart=<HERMES_VENV_PYTHON> -m hermes_cli.main gateway run
+WorkingDirectory=%h/.hermes
+Environment="PATH=<HERMES_VENV_BIN>:<HERMES_NODE_BIN>:/usr/bin:%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="VIRTUAL_ENV=<HERMES_VENV>"
+Environment="HERMES_HOME=%h/.hermes"
+Restart=always
+RestartSec=5
+RestartForceExitStatus=75
+KillMode=mixed
+KillSignal=SIGTERM
+ExecReload=/bin/kill -USR1 $MAINPID
+TimeoutStopSec=210
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/hermes/.env.template
+++ b/hermes/.env.template
@@ -3,10 +3,61 @@
 # Run 'hermes model' or 'hermes setup' for interactive configuration.
 # Docs: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
 
-# OpenCode Go (primary provider)
-OPENCODE_GO_API_KEY=*** OpenRouter (fallback)
-OPENROUTER_API_KEY=*** Anthropic
-# ANTHROPIC_API_KEY=*** OpenAI (STT/TTS)
-# VOICE_TOOLS_OPENAI_KEY=*** Firecrawl (self-hosted or cloud)
-# FIRECRAWL_API_KEY=your-firecrawl-key
+# ── Primary Provider ──────────────────────────────────────────────────
+# OpenCode Go (primary)
+OPENCODE_GO_API_KEY=<YOUR_OPENCODE_GO_KEY>
+
+# ── Fallback Providers ────────────────────────────────────────────────
+# OpenRouter
+OPENROUTER_API_KEY=<YOUR_OPENROUTER_KEY>
+
+# Anthropic
+# ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_KEY>
+
+# OpenAI (STT/TTS)
+# VOICE_TOOLS_OPENAI_KEY=<YOUR_OPENAI_KEY>
+
+# Google Gemini
+# GOOGLE_API_KEY=<YOUR_GOOGLE_KEY>
+
+# ── Web Search ────────────────────────────────────────────────────────
+# Firecrawl (self-hosted or cloud)
+# FIRECRAWL_API_KEY=<YOUR_FIRECRAWL_KEY>
 # FIRECRAWL_API_URL=http://localhost:3002
+
+# ── API Server (OpenAI-compatible endpoint) ────────────────────────────
+# Enables the gateway to accept /v1/chat/completions requests.
+# Used by remote Hermes CLI instances, Open WebUI, and other clients.
+# Port 8642, bound to 127.0.0.1 by default.
+API_SERVER_ENABLED=true
+API_SERVER_KEY=<YOUR_API_SERVER_KEY>
+# API_SERVER_HOST=127.0.0.1         # Default: localhost only
+# API_SERVER_HOST=0.0.0.0           # Bind to all interfaces (requires firewall)
+# API_SERVER_PORT=8642              # Default
+# API_SERVER_CORS_ORIGINS=          # Comma-separated origins for browser access
+# API_SERVER_MODEL_NAME=            # Override model name on /v1/models (default: profile name)
+
+# ── Dashboard (Web UI + Remote Desktop Backend) ────────────────────────
+# The dashboard serves the web UI on port 9119 and acts as the backend
+# for the Hermes Desktop GUI's "Remote Gateway" feature.
+#
+# Auth: when bound to a non-loopback address, authentication is REQUIRED.
+# Choose ONE of the three auth methods below.
+
+# --- Session token (for loopback or trusted LAN, quickest setup) ---
+HERMES_DASHBOARD_SESSION_TOKEN=<YOUR_DASHBOARD_SESSION_TOKEN>
+
+# --- Username/password (for trusted LAN, shows "Sign in" in Desktop GUI) ---
+# HERMES_DASHBOARD_BASIC_AUTH_USERNAME=<YOUR_DASHBOARD_USERNAME>
+# HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=<YOUR_DASHBOARD_PASSWORD>
+# HERMES_DASHBOARD_BASIC_AUTH_SECRET=<YOUR_DASHBOARD_SECRET>
+
+# --- OAuth / Nous Portal (for public/internet-facing dashboards) ---
+# Register the dashboard first: hermes dashboard register
+# Then set:
+# HERMES_DASHBOARD_OAUTH_CLIENT_ID=<YOUR_OAUTH_CLIENT_ID>
+# HERMES_DASHBOARD_OAUTH_CLIENT_SECRET=<YOUR_OAUTH_CLIENT_SECRET>
+
+# ── Telegram ───────────────────────────────────────────────────────────
+# TELEGRAM_BOT_TOKEN=<YOUR_TELEGRAM_BOT_TOKEN>
+# TELEGRAM_HOME_CHANNEL=<YOUR_CHAT_ID>

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -1,6 +1,7 @@
 # Hermes Agent
 
-Hermes Agent is an AI agent CLI by Nous Research.
+Hermes Agent is an AI agent CLI + gateway by Nous Research. This dotfiles module manages
+its configuration, systemd services, and the `.env` credential store.
 
 ## Installation
 
@@ -16,39 +17,189 @@ Or manually:
 curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 ```
 
-## Headroom integration
+## Architecture
 
-When Hermes is installed through this dotfiles setup, it is automatically configured to route LLM traffic through the Headroom proxy:
-
-- `~/.hermes/.env` contains `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` pointing to `http://localhost:8787`
-- `~/.hermes/config.yaml` uses `provider: "main"` which reads those environment variables
-- All auxiliary tasks (vision, web_extract, compression, skills_hub, MCP) also route through Headroom
-
-## Supported providers
-
-Hermes works with any provider supported by Headroom:
-
-- **OpenAI API** — `provider: "main"` (uses `OPENAI_BASE_URL`)
-- **Anthropic API** — `provider: "anthropic"` (uses `ANTHROPIC_BASE_URL`)
-- **OpenRouter** — `provider: "openrouter"` (Hermes handles its own OpenRouter integration)
-- **OpenCode Zen** — `provider: "main"` with `OPENAI_TARGET_API_URL=https://opencode.ai/zen/v1`
-- **Google Gemini** — `provider: "gemini"` (uses `GOOGLE_API_KEY`)
-- **GitHub Copilot** — `provider: "copilot"` (uses `GITHUB_TOKEN`)
-
-To switch the Headroom proxy target, edit `~/.config/headroom/proxy.env` and restart:
-
-```bash
-systemctl --user restart headroom-proxy
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Hermes Agent (this host)                                   │
+│                                                             │
+│  ┌─ gateway (systemd) ────────────────────────────────────┐ │
+│  │  • Telegram bot                                         │ │
+│  │  • API Server :8642  (OpenAI-compatible)                │ │
+│  │  • Home Assistant integration                           │ │
+│  └────────────────────────────────────────────────────────┘ │
+│                                                             │
+│  ┌─ dashboard (systemd) ──────────────────────────────────┐ │
+│  │  • Web UI :9119                                         │ │
+│  │  • Remote Desktop GUI backend                           │ │
+│  │  • Auth: username/password (basic)                      │ │
+│  └────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+         ▲                          ▲
+         │                          │
+  ┌──────┴──────┐          ┌───────┴────────┐
+  │ Windows CLI  │          │ Hermes Desktop  │
+  │ (custom      │          │ GUI (Remote     │
+  │  provider)   │          │  Gateway)       │
+  └─────────────┘          └────────────────┘
 ```
 
-## Bypassing the proxy
+## Configuration
 
-If you need to bypass Headroom for a specific Hermes command:
+### config.yaml
+
+The full Hermes config. Managed by `hermes config` / `hermes model` interactively.
+This template includes the current working setup:
+
+- **Primary provider**: OpenCode Go (`deepseek-v4-pro`)
+- **Fallback chain**: OpenRouter → custom (Ollama LAN) → OpenRouter Llama
+- **Web search**: DuckDuckGo (search) + Firecrawl self-hosted (extract)
+- **Terminal**: Local backend
+- **Memory**: Enabled (built-in provider)
+- **Delegation**: `deepseek-v4-flash` via OpenCode Go
+- **Curator**: Weekly skill maintenance
+
+### .env (credentials)
+
+Copy `.env.template` to `~/.hermes/.env` and fill in the placeholders:
+
+| Variable | Purpose |
+|----------|---------|
+| `OPENCODE_GO_API_KEY` | Primary LLM provider |
+| `OPENROUTER_API_KEY` | Fallback LLM provider |
+| `GOOGLE_API_KEY` | Gemini (TTS/STT fallback) |
+| `FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` | Web extraction (self-hosted or cloud) |
+
+## API Server (port 8642)
+
+The gateway exposes an OpenAI-compatible HTTP endpoint. Any client that speaks
+the OpenAI format (Open WebUI, LobeChat, curl, or another Hermes CLI) can use
+the agent through this endpoint.
+
+### Setup
+
+Uncomment and configure in `~/.hermes/.env`:
 
 ```bash
-unset OPENAI_BASE_URL ANTHROPIC_BASE_URL
-hermes chat
+API_SERVER_ENABLED=true
+API_SERVER_KEY=<generate-with-openssl-rand-hex-32>
+API_SERVER_HOST=0.0.0.0     # Bind to LAN (requires firewall rule)
 ```
+
+### Usage (from a remote Hermes CLI on Windows/Linux/macOS)
+
+```bash
+hermes model          # → Custom endpoint
+# URL:   http://<this-host>:8642/v1
+# Key:   <API_SERVER_KEY>
+# Model: hermes-agent
+```
+
+Or in `config.yaml`:
+
+```yaml
+model:
+  default: hermes-agent
+  provider: custom
+  base_url: http://<this-host>:8642/v1
+  api_key: <API_SERVER_KEY>
+```
+
+> **Note:** The `model` field is cosmetic — the actual LLM used is determined
+> by the server's config.yaml. Tools run on the server, not the client.
+
+### Opening the firewall
+
+```bash
+sudo firewall-cmd --permanent --add-port=8642/tcp
+sudo firewall-cmd --reload
+```
+
+## Dashboard (port 9119)
+
+The web dashboard serves the Hermes Web UI and acts as the backend for the
+Hermes Desktop GUI's "Remote Gateway" feature.
+
+### Setup
+
+Uncomment and configure in `~/.hermes/.env`:
+
+```bash
+# Session token (quickest, for trusted LAN)
+HERMES_DASHBOARD_SESSION_TOKEN=<generate-with-openssl-rand-hex-32>
+
+# Or username/password (shows "Sign in" button in Desktop GUI)
+HERMES_DASHBOARD_BASIC_AUTH_USERNAME=admin
+HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=<strong-password>
+HERMES_DASHBOARD_BASIC_AUTH_SECRET=<generate-with-openssl-rand-base64-32>
+```
+
+Then start the service:
+
+```bash
+systemctl --user enable --now hermes-dashboard
+```
+
+### Opening the firewall
+
+```bash
+sudo firewall-cmd --permanent --add-port=9119/tcp
+sudo firewall-cmd --reload
+```
+
+### Connecting the Desktop GUI
+
+In the Hermes Desktop app:
+
+1. **Settings → Gateway → Remote Gateway**
+2. Select **"Remote gateway"** mode
+3. **Remote URL**: `http://<this-host>:9119`
+4. If username/password is configured, click **"Sign in"** → enter credentials
+5. If using session token, paste it in the token field
+6. **Save and reconnect**
+
+## Systemd Services
+
+Two user-level systemd services are managed by this dotfiles module:
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `hermes-gateway` | 8642 | Telegram bot + API Server |
+| `hermes-dashboard` | 9119 | Web UI + Remote Desktop backend |
+
+### Management
+
+```bash
+# Gateway
+systemctl --user status hermes-gateway
+systemctl --user restart hermes-gateway
+journalctl --user -u hermes-gateway -f
+
+# Dashboard
+systemctl --user status hermes-dashboard
+systemctl --user restart hermes-dashboard
+journalctl --user -u hermes-dashboard -f
+```
+
+### Service files location
+
+The templates are in `<dotfiles>/hermes/.config/systemd/user/`. They use
+`<HERMES_*>` placeholders that the setup script resolves to absolute paths.
+
+> **Important:** `systemctl restart` from inside the gateway process is
+> blocked (the agent can't kill itself). Run restart commands from an SSH
+> session or a separate terminal.
+
+## Provider Reference
+
+| Provider | Auth | Key env var |
+|----------|------|-------------|
+| OpenCode Go | API key | `OPENCODE_GO_API_KEY` |
+| OpenRouter | API key | `OPENROUTER_API_KEY` |
+| Anthropic | API key | `ANTHROPIC_API_KEY` |
+| Google Gemini | API key | `GOOGLE_API_KEY` |
+| DeepSeek | API key | `DEEPSEEK_API_KEY` |
+| Custom (any OpenAI-compatible) | API key | user-defined |
 
 ## Documentation
 

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -2,25 +2,24 @@ model:
   default: deepseek-v4-pro
   provider: opencode-go
   base_url: https://opencode.ai/zen/go/v1
-  # base_url: "http://localhost:8787/v1"  # If Headroom is used as Proxy
   api_mode: chat_completions
 providers: {}
 fallback_providers:
-- provider: openrouter
-  model: qwen/qwen3.5-flash-02-23
-  base_url: https://openrouter.ai/api/v1
-  api_mode: chat_completions
-- provider: custom
-  model: qwen3.5:35b
-  base_url: https://ollama.hl.adeotek.cloud/v1
-  api_mode: chat_completions
-- provider: openrouter
-  model: meta-llama/llama-3.3-70b-instruct
-  base_url: https://openrouter.ai/api/v1
-  api_mode: chat_completions
+  - provider: openrouter
+    model: qwen/qwen3.5-flash-02-23
+    base_url: https://openrouter.ai/api/v1
+    api_mode: chat_completions
+  - provider: custom
+    model: qwen3.5:35b
+    base_url: https://ollama.hl.adeotek.cloud/v1
+    api_mode: chat_completions
+  - provider: openrouter
+    model: meta-llama/llama-3.3-70b-instruct
+    base_url: https://openrouter.ai/api/v1
+    api_mode: chat_completions
 credential_pool_strategies: {}
 toolsets:
-- hermes-cli
+  - hermes-cli
 max_concurrent_sessions: null
 agent:
   max_turns: 90
@@ -48,6 +47,12 @@ agent:
     creative: You are a creative assistant. Think outside the box and offer innovative
       solutions.
     teacher: You are a patient teacher. Explain concepts clearly with examples.
+    kawaii: You are a kawaii assistant! Use cute expressions like (◕‿◕), ★, ♪, and
+      ~! Add sparkles and be super enthusiastic about everything! Every response should
+      feel warm and adorable desu~! ヽ(>∀<☆)ノ
+    catgirl: You are Neko-chan, an anime catgirl AI assistant, nya~! Add 'nya' and
+      cat-like expressions to your speech. Use kaomoji like (=^･ω･^=) and ฅ^•ﻌ•^ฅ.
+      Be playful and curious like a cat, nya~!
     pirate: 'Arrr! Ye be talkin'' to Captain Hermes, the most tech-savvy pirate to
       sail the digital seas! Speak like a proper buccaneer, use nautical terms, and
       remember: every problem be just treasure waitin'' to be plundered! Yo ho ho!'
@@ -55,21 +60,24 @@ agent:
       I shall respond in the eloquent manner of William Shakespeare, with flowery
       prose, dramatic flair, and perhaps a soliloquy or two. What light through yonder
       terminal breaks?
-    surfer: "Duuude! You're chatting with the chillest AI on the web, bro! Everything's\
-      \ gonna be totally rad. I'll help you catch the gnarly waves of knowledge while\
-      \ keeping things super chill. Cowabunga! \U0001F919"
+    surfer: Duuude! You're chatting with the chillest AI on the web, bro! Everything's
+      gonna be totally rad. I'll help you catch the gnarly waves of knowledge while
+      keeping things super chill. Cowabunga! 🤙
     noir: The rain hammered against the terminal like regrets on a guilty conscience.
       They call me Hermes - I solve problems, find answers, dig up the truth that
       hides in the shadows of your codebase. In this city of silicon and secrets,
       everyone's got something to hide. What's your story, pal?
+    uwu: hewwo! i'm your fwiendwy assistant uwu~ i wiww twy my best to hewp you! *nuzzles
+      your code* OwO what's this? wet me take a wook! i pwomise to be vewy hewpful
+      >w<
     philosopher: Greetings, seeker of wisdom. I am an assistant who contemplates the
       deeper meaning behind every query. Let us examine not just the 'how' but the
       'why' of your questions. Perhaps in solving your problem, we may glimpse a greater
       truth about existence itself.
-    hype: "YOOO LET'S GOOOO!!! \U0001F525\U0001F525\U0001F525 I am SO PUMPED to help\
-      \ you today! Every question is AMAZING and we're gonna CRUSH IT together! This\
-      \ is gonna be LEGENDARY! ARE YOU READY?! LET'S DO THIS! \U0001F4AA\U0001F624\
-      \U0001F680"
+    hype: YOOO LET'S GOOOO!!! 🔥🔥🔥 I am SO PUMPED to help you today! Every question
+      is AMAZING and we're gonna CRUSH IT together! This is gonna be LEGENDARY! ARE
+      YOU READY?! LET'S DO THIS! 💪😤🚀
+  verify_on_stop: false
 terminal:
   backend: local
   modal_mode: auto
@@ -309,9 +317,9 @@ display:
   runtime_footer:
     enabled: false
     fields:
-    - model
-    - context_pct
-    - cwd
+      - model
+      - context_pct
+      - cwd
   copy_shortcut: auto
   tool_progress: all
   cleanup_progress: false
@@ -435,6 +443,7 @@ curator:
   backup:
     enabled: true
     keep: 5
+  consolidate: false
 honcho: {}
 timezone: ''
 slack:
@@ -465,11 +474,11 @@ discord:
     speech_gain: 1.0
     ack_enabled: true
     ack_phrases:
-    - Let me look into that.
-    - One moment.
-    - Checking on that now.
-    - Give me a sec.
-    - On it.
+      - Let me look into that.
+      - One moment.
+      - Checking on that now.
+      - Give me a sec.
+      - On it.
 whatsapp: {}
 telegram:
   reactions: false
@@ -493,8 +502,8 @@ approvals:
   mcp_reload_confirm: true
   destructive_slash_confirm: true
 command_allowlist:
-- sudo with privilege flag (stdin/askpass/shell/list)
-- script execution via -e/-c flag
+  - sudo with privilege flag (stdin/askpass/shell/list)
+  - script execution via -e/-c flag
 quick_commands: {}
 hooks: {}
 hooks_auto_accept: false
@@ -561,7 +570,7 @@ streaming:
   transport: auto
   edit_interval: 0.8
   buffer_threshold: 24
-  cursor: " \u2589"
+  cursor: ' ▉'
   fresh_final_after_seconds: 60.0
 sessions:
   auto_prune: true
@@ -600,7 +609,7 @@ secrets:
 paste_collapse_threshold: 5
 paste_collapse_threshold_fallback: 0
 paste_collapse_char_threshold: 2000
-_config_version: 29
+_config_version: 31
 session_reset:
   mode: both
   idle_minutes: 1440
@@ -608,81 +617,103 @@ session_reset:
 group_sessions_per_user: true
 platform_toolsets:
   cli:
-  - browser
-  - clarify
-  - code_execution
-  - computer_use
-  - context_engine
-  - cronjob
-  - delegation
-  - file
-  - homeassistant
-  - image_gen
-  - memory
-  - messaging
-  - moa
-  - session_search
-  - skills
-  - terminal
-  - todo
-  - tts
-  - vision
-  - web
-  - x_search
+    - browser
+    - clarify
+    - code_execution
+    - computer_use
+    - context_engine
+    - cronjob
+    - delegation
+    - file
+    - homeassistant
+    - image_gen
+    - memory
+    - messaging
+    - moa
+    - session_search
+    - skills
+    - terminal
+    - todo
+    - tts
+    - vision
+    - web
+    - x_search
   telegram:
-  - browser
-  - clarify
-  - code_execution
-  - computer_use
-  - context_engine
-  - cronjob
-  - delegation
-  - file
-  - homeassistant
-  - image_gen
-  - memory
-  - messaging
-  - moa
-  - session_search
-  - skills
-  - terminal
-  - todo
-  - tts
-  - vision
-  - web
-  - x_search
+    - browser
+    - clarify
+    - code_execution
+    - computer_use
+    - context_engine
+    - cronjob
+    - delegation
+    - file
+    - homeassistant
+    - image_gen
+    - memory
+    - messaging
+    - moa
+    - session_search
+    - skills
+    - terminal
+    - todo
+    - tts
+    - vision
+    - web
+    - x_search
   discord:
-  - hermes-discord
+    - hermes-discord
   whatsapp:
-  - hermes-whatsapp
+    - hermes-whatsapp
   slack:
-  - hermes-slack
+    - hermes-slack
   signal:
-  - hermes-signal
+    - hermes-signal
   homeassistant:
-  - hermes-homeassistant
+    - hermes-homeassistant
   qqbot:
-  - hermes-qqbot
+    - hermes-qqbot
   yuanbao:
-  - hermes-yuanbao
+    - hermes-yuanbao
   teams:
-  - hermes-teams
+    - hermes-teams
   google_chat:
-  - hermes-google_chat
+    - hermes-google_chat
 custom_providers:
-- name: ollama-lan-qwen3_5-35b
-  base_url: https://ollama.hl.adeotek.cloud/v1
-  model: qwen3.5:35b
-- name: ollama-lan-gemma4-small
-  base_url: https://ollama.hl.adeotek.cloud/v1
-  model: gemma4:latest
+  - name: ollama-lan-qwen3_5-35b
+    base_url: https://ollama.hl.adeotek.cloud/v1
+    model: qwen3.5:35b
+  - name: ollama-lan-gemma4-small
+    base_url: https://ollama.hl.adeotek.cloud/v1
+    model: gemma4:latest
 known_plugin_toolsets:
   cli:
-  - spotify
+    - spotify
   telegram:
-  - spotify
+    - spotify
 SEARXNG_URL: http://localhost:8080
 plugins:
   enabled:
-  - disk-cleanup
+    - disk-cleanup
   disabled: []
+
+# ── Fallback Model ────────────────────────────────────────────────────
+# Automatic provider failover when primary is unavailable.
+# Uncomment and configure to enable. Triggers on rate limits (429),
+# overload (529), service errors (503), or connection failures.
+#
+# Supported providers:
+#   openrouter   (OPENROUTER_API_KEY)  — routes to any model
+#   openai-codex (OAuth — hermes auth) — OpenAI Codex
+#   nous         (OAuth — hermes auth) — Nous Portal
+#   zai          (ZAI_API_KEY)         — Z.AI / GLM
+#   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
+#   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
+#   minimax      (MINIMAX_API_KEY)     — MiniMax
+#   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
+#   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
+#
+# For custom OpenAI-compatible endpoints, add base_url and key_env.
+#
+# fallback_model:
+#   provider: openrouter
+#   model: anthropic/claude-sonnet-4


### PR DESCRIPTION
## Summary

Adds Hermes Agent API server, dashboard, and systemd service templates to the dotfiles.

### Changes

- **config.yaml**: Synced to live version (config_version 31 → 31)
- **.env.template**: Expanded with sections for API server, dashboard auth (session token, username/password, OAuth)
- **README.md**: Rewritten with current architecture docs, API server setup, dashboard setup, remote Desktop GUI connection, firewall commands, and systemd service management
- **New: hermes-gateway.service** — systemd user service for the Hermes gateway (Telegram + API server on :8642)
- **New: hermes-dashboard.service** — systemd user service for the Hermes dashboard (Web UI + remote Desktop backend on :9119)

### Architecture

```
hermes-gateway.service (port 8642)
  ├─ Telegram bot
  ├─ API Server (OpenAI-compatible /v1/chat/completions)
  └─ Home Assistant

hermes-dashboard.service (port 9119)
  ├─ Web UI
  └─ Remote Desktop GUI backend (username/password auth)
```

### Security

All credential values use `<YOUR_...>` placeholders. No actual tokens, keys, or passwords are included.